### PR TITLE
Allow webkitgtk 4.1

### DIFF
--- a/formiko/renderer.py
+++ b/formiko/renderer.py
@@ -14,7 +14,10 @@ from docutils.writers.s5_html import Writer as WriterS5
 from docutils.writers.pep_html import Writer as WriterPep
 
 from gi import require_version
-require_version('WebKit2', '4.0')   # noqa
+try:
+    require_version('WebKit2', '4.1')   # noqa
+except ValueError:
+    require_version('WebKit2', '4.0')   # noqa
 
 from gi.repository.WebKit2 import WebView, PrintOperation, FindOptions, \
     LoadEvent # noqa


### PR DESCRIPTION
webkitgtk 4.1 is the same as 4.0 except that it uses libsoup3 instead of libsoup2.4

Since formiko doesn't use libsoup directly or any other library that uses libsoup, this is an easy switch.