### PR TITLE
Add codespell for automated spell-checking, and fix the typos it found

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: rst-linter
   
   - repo: https://github.com/codespell-project/codespell
-    # Configuration for codespell is in .pre-commit-config.yaml
+    # Configuration for codespell is in pyproject.toml
     rev: v2.4.2
     hooks:
     - id: codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,9 @@ repos:
     rev: v1.0.1
     hooks:
       - id: rst-linter
+  
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in .pre-commit-config.yaml
+    rev: v2.4.2
+    hooks:
+    - id: codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: v1.0.1
     hooks:
       - id: rst-linter
-  
+
   - repo: https://github.com/codespell-project/codespell
     # Configuration for codespell is in pyproject.toml
     rev: v2.4.2

--- a/ChangeLog
+++ b/ChangeLog
@@ -145,10 +145,10 @@ Version 1.2.1
 Version 1.2.0
 
   * vim with working application menu
-  * realy disabled accels for vim
+  * really disabled accels for vim
   * toggle buttons to on/off editor and preview
   * tabs setting in status bar
-  * preferences are save automatical
+  * preferences are saved automatically
   * auto indent is switchable
   * showing line numbers is switchable
   * right margin is switchable
@@ -205,7 +205,7 @@ Version 1.0.0
   * using Gtk.Application instead of GObject.GObject
   * full working
   * python3 support
-  * crashing tread does crash gtk
+  * crashing thread does crash gtk
   * using Gtk+3
   * installable project
   * first based function

--- a/ChangeLog
+++ b/ChangeLog
@@ -82,7 +82,7 @@ Version 2.0.0
 Version 1.5.0
 
   * fix local url with href anchor
-  * M2R convertor support for another MarkDown parsing way
+  * M2R converter support for another MarkDown parsing way
   * check_version command for version check in all files
     in repository
   * bad parser in config fix
@@ -168,7 +168,7 @@ Version 1.1.0
   * info for Debian and NetBSD users
   * SourceView editor settings:
      - tab width
-     - usinng spaces intead of tabs
+     - using spaces instead of tabs
      - 80 chars length line visualization
      - periodic saving file
 
@@ -187,7 +187,7 @@ Version 1.0.0
   * stable version 1.0.0
   * right source distribution
   * desktop integration
-  * litle bit fixies
+  * little bit fixies
   * application icon from petr simcik
   * final clean code
   * Small fixies from TODO:

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Requirements:
 * WebKitGTK 6.x
 * GtkSourceView 5.x
 * libspelling 1.x
-* git files for all Gtk libraries
+* gir files for all Gtk libraries
 * vte - neovim support
 * docutils - reStructuredText support
 * jsonpath-ng - JSON Search path support

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Features:
 It supports these parsers and writers:
 
 * Docutils reStructuredText parser - https://www.docutils.org
-* MarkDown to reStructuredText convertor (M2R2) -
+* MarkDown to reStructuredText converter (M2R2) -
   https://github.com/crossnox/m2r2
 * Docutils HTML4, HTML5, S5/HTML slide show and PEP HTML writer -
   http://docutils.sourceforge.net
@@ -89,7 +89,7 @@ Requirements:
 * WebKitGTK 6.x
 * GtkSourceView 5.x
 * libspelling 1.x
-* gir files for all Gtk libraries
+* git files for all Gtk libraries
 * vte - neovim support
 * docutils - reStructuredText support
 * jsonpath-ng - JSON Search path support

--- a/formiko/application.py
+++ b/formiko/application.py
@@ -119,7 +119,7 @@ class Application(Adw.Application):
             log_default_handler(
                 None,
                 LogLevelFlags.LEVEL_CRITICAL,
-                "Vim version needs Vte 2.91 gir!",
+                "Vim version needs Vte 2.91 git!",
                 None,
             )
             return 1

--- a/formiko/application.py
+++ b/formiko/application.py
@@ -119,7 +119,7 @@ class Application(Adw.Application):
             log_default_handler(
                 None,
                 LogLevelFlags.LEVEL_CRITICAL,
-                "Vim version needs Vte 2.91 git!",
+                "Vim version needs Vte 2.91 gir!",
                 None,
             )
             return 1

--- a/formiko/preferences.py
+++ b/formiko/preferences.py
@@ -18,7 +18,7 @@ def set_tooltip(item: Gtk.CheckButton, enabled: bool, val: dict):
     tooltip = ""
     if not enabled:
         package = val.get("package", val["title"])
-        tooltip = f"Please intall {package}."
+        tooltip = f"Please install {package}."
 
     if "url" in val:
         tooltip += f" More info at {val['url']}"

--- a/formiko/renderer.py
+++ b/formiko/renderer.py
@@ -617,7 +617,7 @@ class Renderer(Overlay):
         if self.src is None:
             return
         state, html, mime_type = self.render_output()
-        if html and self.__win.runing:
+        if html and self.__win.running:
             if mime_type == "text/html" and "</head>" in html:
                 if not self.style:
                     theme_css = (

--- a/formiko/renderer.py
+++ b/formiko/renderer.py
@@ -134,9 +134,9 @@ NOT_FOUND = """
 <html>
   <head></head>
   <body>
-    <h1>Commponent {title} Not Found!</h1>
+    <h1>Component {title} Not Found!</h1>
     <p>Component <b>{title}</b> which you want to use is not found.
-       See <a href="{url}">{url}</a> for mor details and install it
+       See <a href="{url}">{url}</a> for more details and install it
        to system.
     </p>
   </body>
@@ -577,7 +577,7 @@ class Renderer(Overlay):
                 }
                 if self.__writer["key"] == "pep":
                     kwargs["reader_name"] = "pep"
-                    kwargs.pop("parser")  # pep is allways rst
+                    kwargs.pop("parser")  # pep is always rst
                 html = publish_string(**kwargs).decode("utf-8")
                 return True, html, "text/html"
 

--- a/formiko/shortcuts.py
+++ b/formiko/shortcuts.py
@@ -142,7 +142,7 @@ class GeneralGroup(ShortcutsGroup):
     """General application shortcuts group."""
 
     def __init__(self, editor_type):
-        super().__init__(title="Genaral")
+        super().__init__(title="General")
 
         self.append(
             ShortcutsShortcut(accelerator="<Control>n", title="New Document"),

--- a/formiko/sourceview.py
+++ b/formiko/sourceview.py
@@ -72,7 +72,7 @@ def _list_continuation_marker(line_text: str) -> "str | None":
 
 
 class SourceView(Gtk.ScrolledWindow, ActionHelper):
-    """Widget containted SourceView."""
+    """Widget contained SourceView."""
 
     __file_name = ""
     __last_changes = 0

--- a/formiko/sourceview.py
+++ b/formiko/sourceview.py
@@ -214,10 +214,10 @@ class SourceView(Gtk.ScrolledWindow, ActionHelper):
     def position(self):
         """Return cursor position."""
         adj = self.source_view.get_vadjustment()
-        hight = self.get_height()
+        height = self.get_height()
         value = adj.get_value()
         if value:
-            return adj.get_value() / (adj.get_upper() - hight)
+            return adj.get_value() / (adj.get_upper() - height)
         return 0
 
     @property

--- a/formiko/status_menu.py
+++ b/formiko/status_menu.py
@@ -110,7 +110,7 @@ class LineColPopover(Gtk.Popover):
         return vbox
 
     def on_margin_toggle(self, widget, spin):
-        """Change sensitve when margin toggle was changed."""
+        """Change sensitive when margin toggle was changed."""
         spin.set_sensitive(widget.get_active())
 
 

--- a/formiko/user.py
+++ b/formiko/user.py
@@ -40,7 +40,7 @@ def smart_bool(value):
 
 
 class SmartParser(ConfigParser):
-    """ConfigParser without rising excpetion whehn something does not exist."""
+    """ConfigParser without rising exception whehn something does not exist."""
 
     def smart_get(self, obj, key, conv=str, sec="main"):
         """Get with conversion function."""
@@ -105,7 +105,7 @@ class UserPreferences:
             log_default_handler(
                 "Application",
                 LogLevelFlags.LEVEL_WARNING,
-                f"Unknow parser `{self.parser}' in config, set default.",
+                f"Unknown parser `{self.parser}' in config, set default.",
             )
             self.parser = "rst"
         cp.smart_get(self, "writer")

--- a/formiko/user.py
+++ b/formiko/user.py
@@ -40,7 +40,7 @@ def smart_bool(value):
 
 
 class SmartParser(ConfigParser):
-    """ConfigParser without rising exception whehn something does not exist."""
+    """ConfigParser without raising exception when something does not exist."""
 
     def smart_get(self, obj, key, conv=str, sec="main"):
         """Get with conversion function."""

--- a/formiko/vim.py
+++ b/formiko/vim.py
@@ -101,7 +101,7 @@ class VimEditor(Vte.Terminal):
         self._nvim_call(lambda: self.nvim.command(command))
 
     def get_vim_changes(self):
-        """Retun number of changes in vim."""
+        """Return number of changes in vim."""
         return self.vim_remote_expr("b:changedtick") or 0
 
     def get_vim_lines(self):
@@ -109,7 +109,7 @@ class VimEditor(Vte.Terminal):
         return self.vim_remote_expr("line('$')") or 0
 
     def get_vim_get_buffer(self, count):
-        """Retun text from vim."""
+        """Return text from vim."""
         buff = self.vim_remote_expr(f"getline(0, {count})")
         return "\n".join(buff)
 

--- a/formiko/vim.py
+++ b/formiko/vim.py
@@ -93,7 +93,7 @@ class VimEditor(Vte.Terminal):
             return default
 
     def vim_remote_expr(self, command):
-        """Do expresion on vim server and return value."""
+        """Do expression on vim server and return value."""
         return self._nvim_call(lambda: self.nvim.eval(command))
 
     def vim_remote_send(self, command):
@@ -151,7 +151,7 @@ class VimEditor(Vte.Terminal):
 
     @property
     def file_name(self):
-        """Return file openned in vim."""
+        """Return file opened in vim."""
         __file_name = self.vim_remote_expr("@%")
         if __file_name != self.__file_name:
             _, ext = splitext(__file_name)

--- a/formiko/window.py
+++ b/formiko/window.py
@@ -88,7 +88,7 @@ class AppWindow(Adw.ApplicationWindow):
         :param str file_name: Path to open on startup.
         :param bool no_initial_tab: Skip initial tab (drag-receive windows).
         """
-        self.runing = True
+        self.running = True
         self.editor_type = editor_type
         self.focused = None
         self.search_way = SearchWay.NEXT
@@ -724,7 +724,7 @@ class AppWindow(Adw.ApplicationWindow):
                     and doc.editor_type == EditorType.SOURCE
                 ):
                     doc.editor.save()
-        self.runing = False
+        self.running = False
         for doc in self._iter_doc_pages():
             doc.stop()
             if doc.editor_type == EditorType.VIM:
@@ -733,7 +733,7 @@ class AppWindow(Adw.ApplicationWindow):
 
     def destroy_from_vim(self, vim_widget=None, *args):
         """Close the tab whose VimEditor exited."""
-        self.runing = False
+        self.running = False
         for doc in list(self.iter_doc_pages()):
             if doc.editor_type == EditorType.VIM and (
                 vim_widget is None or doc.editor is vim_widget

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ testpaths = ["tests"]
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.svg,*.css'
+skip = '.git,.git-meta,.gitignore,.gitattributes,*.svg,*.css,*.min.*,build,dist,*.egg-info'
 check-hidden = true
 # ignore-regex = ''
 # ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,4 +63,5 @@ testpaths = ["tests"]
 skip = '.git,.git-meta,.gitignore,.gitattributes,*.svg,*.css,*.min.*,build,dist,*.egg-info'
 check-hidden = true
 # ignore-regex = ''
-# ignore-words-list = ''
+# gir - GObject Introspection Repository files (.gir), a GNOME term
+ignore-words-list = 'gir'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,10 @@ include = ["formiko*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,.gitignore,.gitattributes,*.svg,*.css'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''


### PR DESCRIPTION
Add codespell for automated spell-checking, and fix the typos it found.

More about codespell: https://github.com/codespell-project/codespell — I have
introduced it to a hundred+ projects already, mostly with positive feedback
(see the [improveit-dashboard note](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)).
The CI workflow has `permissions: contents: read` so it is also safe.

## Summary

- Configure codespell in `pyproject.toml`, wire it into `.pre-commit-config.yaml`
  and a lightweight GitHub Actions workflow (already in place from prior commits
  on this branch — this PR extends them and applies the fixes).
- Fix 18 typos codespell caught (mix of `codespell -w` for single-suggestion
  hits and manual context-based decisions for ambiguous ones), plus 2 extra
  typos it does not know about (`whehn`, `rising`).

## Notable changes

<details>
<summary>Ambiguous typos — required context review</summary>

Codespell offers multiple suggestions for these; the fix was chosen from
surrounding code:

- `formiko/window.py` + `formiko/renderer.py`: rename attribute
  `AppWindow.runing` → `AppWindow.running` (and its cross-file read in
  `Renderer._render`). **This is a real attribute rename** — the only external
  reference is `Renderer.__win.runing`, which is updated in the same commit.
- `formiko/vim.py`: `Retun` → `Return` in two docstrings.
- `formiko/sourceview.py`: local variable `hight` → `height` (value comes
  from `self.get_height()`).
- `ChangeLog`: `realy` → `really`, `automatical` → `automatically`,
  `tread` → `thread` (thread-related crash entry).

</details>

<details>
<summary>Non-ambiguous typos — applied with codespell -w</summary>

Committed with `datalad run` so the exact command is recorded in git and
re-runnable:

`convertor`→`converter`, `usinng`→`using`, `intead`→`instead`, `litle`→`little`,
`intall`→`install`, `Commponent`→`Component`, `mor`→`more`, `allways`→`always`,
`Genaral`→`General`, `containted`→`contained`, `sensitve`→`sensitive`,
`excpetion`→`exception`, `Unknow`→`Unknown`, `expresion`→`expression`,
`openned`→`opened`.

</details>

<details>
<summary>False positive fixed + whitelisted: `gir`</summary>

`codespell -w` initially replaced `gir` with `git` in two places:

- `README.rst` requirements list: `* gir files for all Gtk libraries`
- `formiko/application.py` critical log message: `"Vim version needs Vte 2.91 gir!"`

`gir` here is not a typo — it refers to **GObject Introspection Repository**
(`.gir`) files, the interface descriptions GNOME libraries ship. Both edits
were reverted, and `gir` was added to `ignore-words-list` in `pyproject.toml`
with a comment explaining why, so future runs won't re-flag it.

</details>

<details>
<summary>Extra typos codespell doesn't know about</summary>

While reviewing the diff, spotted two typos in the `SmartParser` docstring
(`formiko/user.py`) that codespell missed. Fixed manually:

- `rising` → `raising`
- `whehn` → `when`

</details>

<details>
<summary>Config / infrastructure details</summary>

- `pyproject.toml` `[tool.codespell]` skip list extended with `.git-meta`
  (author-workflow scratch dir), minified files, `build/`, `dist/`, and
  `*.egg-info`.
- `.pre-commit-config.yaml` codespell hook: comment fixed (previously
  pointed at itself; the config actually lives in `pyproject.toml`).
- `.github/workflows/codespell.yml` triggers on push to `master` and PRs
  targeting `master`, with `permissions: contents: read`.

</details>

## Testing

- `uvx codespell` — zero errors
- `uvx pre-commit run --all-files` — all hooks pass (ruff, flake8, rst-linter,
  codespell, whitespace/EOF fixers, check-yaml)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code
